### PR TITLE
Check for missing description

### DIFF
--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -24,6 +24,7 @@ pub enum OsedaCheckError {
     BadGitCredentials(String),
     DirectoryNameMismatch(String),
     CouldNotPingLocalPresentation(String),
+    MissingDescription(String)
 }
 
 impl std::error::Error for OsedaCheckError {}
@@ -40,6 +41,9 @@ impl std::fmt::Display for OsedaCheckError {
             }
             Self::CouldNotPingLocalPresentation(msg) => {
                 write!(f, "Could not ping localhost after project was ran {}", msg)
+            }
+            Self::MissingDescription(msg) => {
+                write!(f, "Config file is missing description {}", msg)
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -344,7 +344,7 @@ mod test {
             tags: vec![Tag::ComputerScience],
             last_updated: chrono::Utc::now(),
             color: Color::Black.into_hex(),
-            description: String::new(),
+            description: String::from("Test Description"),
         };
 
         let fake_dir = Path::new("/tmp/oseda");

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,7 +288,7 @@ mod test {
             tags: vec![Tag::ComputerScience],
             last_updated: chrono::Utc::now(),
             color: Color::Black.into_hex(),
-            description: String::new(),
+            description: String::from("Test Description"),
         };
 
         let fake_dir = Path::new("/tmp/my-project");
@@ -306,7 +306,7 @@ mod test {
             tags: vec![Tag::ComputerScience],
             last_updated: chrono::Utc::now(),
             color: Color::Black.into_hex(),
-            description: String::new(),
+            description: String::from("Test Description"),
         };
 
         let fake_dir = Path::new("/tmp/oseda");

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,13 @@ pub fn validate_config(
         ));
     }
 
+    if conf.description.is_empty() {
+        return Err(OsedaCheckError::MissingDescription(
+            "Description is missing or empty. Please update the oseda-config.json".to_owned(),
+        ))
+    }
+
+
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,7 @@ pub struct OsedaConfig {
     // effectively mutable. Will get updated on each deployment
     pub last_updated: DateTime<Utc>,
     pub color: String,
+    // description must not be empty for check/deploy
     pub description: String
 }
 


### PR DESCRIPTION
@22lavonne had an issue where the description was empty and we had to check that when the PR was made. This PR enforces that on `oseda check`  (which gets called in `oseda deploy`) as well.

Closes #69 