### PR TITLE
Use `open::that` for the PR URL

### DIFF
--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -104,6 +104,11 @@ pub fn deploy(opts: DeployOptions) -> Result<(), Box<dyn Error>> {
             println!("Add your presentation to oseda.net by making a Pull Request at:");
             println!();
             println!("{}", pull_request_url);
+
+            if open::that(pull_request_url.clone()).is_err() {
+                return Err(format!("Please visit {pull_request_url} in a browser and submit a pull-request by hand").into());
+            };
+
         }
         None => {
             println!("Error: could not get github username");


### PR DESCRIPTION
Re-use the open that crate for opening the PR url in the browser, so the user doesn't have to copy it into their browser