### PR TITLE
Export Subcommand

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -10,6 +10,7 @@ This document contains the help content for the `oseda` command-line program.
 * [`oseda check`↴](#oseda-check)
 * [`oseda deploy`↴](#oseda-deploy)
 * [`oseda fork`↴](#oseda-fork)
+* [`oseda export`↴](#oseda-export)
 
 ## `oseda`
 
@@ -24,6 +25,7 @@ oseda project scafolding CLI
 * `check` — Check the Oseda project in the working directory for common errors
 * `deploy` — Deploy your Oseda project to github to add to oseda.net
 * `fork` — Fork the library repository to submit your course
+* `export` — Export the Oseda project to a PDF file
 
 
 
@@ -81,6 +83,23 @@ Deploy your Oseda project to github to add to oseda.net
 Fork the library repository to submit your course
 
 **Usage:** `oseda fork`
+
+
+
+## `oseda export`
+
+Export the Oseda project to a PDF file.
+
+**Usage:** `oseda export [OPTIONS]`
+
+###### **Options:**
+
+* `--output <OUTPUT>`
+
+  Default value: `slides.pdf`
+* `--port <PORT>`
+
+  Default value: `3000`
 
 
 

--- a/Usage.md
+++ b/Usage.md
@@ -25,7 +25,7 @@ oseda project scafolding CLI
 * `check` — Check the Oseda project in the working directory for common errors
 * `deploy` — Deploy your Oseda project to github to add to oseda.net
 * `fork` — Fork the library repository to submit your course
-* `export` — Export the Oseda project to a PDF file
+* `export` — Export the Oseda project to a PDF file This will install the npm package `decktape` This relies on a chromium backend, as a result, it may take a while to run
 
 
 
@@ -88,16 +88,16 @@ Fork the library repository to submit your course
 
 ## `oseda export`
 
-Export the Oseda project to a PDF file.
+Export the Oseda project to a PDF file This will install the npm package `decktape` This relies on a chromium backend, as a result, it may take a while to run
 
 **Usage:** `oseda export [OPTIONS]`
 
 ###### **Options:**
 
-* `--output <OUTPUT>`
+* `--output <OUTPUT>` — String name of the output PDF file
 
   Default value: `slides.pdf`
-* `--port <PORT>`
+* `--port <PORT>` — Port the project runs on
 
   Default value: `3000`
 

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -13,3 +13,5 @@ cd test
 
 pwd
 ./oseda init --title ExampleProject --tags economics ComPuterScience --color red --template MaRKDoWN
+
+mv oseda ExampleProject

--- a/src/bin/oseda.rs
+++ b/src/bin/oseda.rs
@@ -2,13 +2,9 @@ use std::{error::Error, process};
 
 use clap::Parser;
 use oseda_cli::{
-    cmd::{
-        check,
-        deploy::{self},
-        fork::{self},
-        init, run,
-    },
-    Cli, Commands,
+    Cli, Commands, cmd::{
+        check, deploy::{self}, export::{self, export}, fork::{self}, init, run
+    }
 };
 
 /// CLI entry point
@@ -31,6 +27,11 @@ fn main() {
             println!("See deployment instructions...");
         }),
         Commands::Fork => fork::fork(),
+        Commands::Export(options) => export::export(options.clone())
+            .map(|_| {
+                println!("Successfully export project to {0}", options.port)
+            })
+            .map_err(|e| e.into()),
     };
 
     // little annoying, but makes the exit code match what users would expect

--- a/src/bin/oseda.rs
+++ b/src/bin/oseda.rs
@@ -2,9 +2,14 @@ use std::{error::Error, process};
 
 use clap::Parser;
 use oseda_cli::{
-    Cli, Commands, cmd::{
-        check, deploy::{self}, export::{self, export}, fork::{self}, init, run
-    }
+    cmd::{
+        check,
+        deploy::{self},
+        export::{self},
+        fork::{self},
+        init, run,
+    },
+    Cli, Commands,
 };
 
 /// CLI entry point
@@ -28,10 +33,7 @@ fn main() {
         }),
         Commands::Fork => fork::fork(),
         Commands::Export(options) => export::export(options.clone())
-            .map(|_| {
-                println!("Successfully export project to {0}", options.port)
-            })
-            .map_err(|e| e.into()),
+            .map(|_| println!("Successfully export project to {0}", options.port)),
     };
 
     // little annoying, but makes the exit code match what users would expect

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,0 +1,61 @@
+use std::{error::Error, process::Command, sync::{Arc, atomic::AtomicBool}};
+
+use clap::Args;
+
+use crate::{cmd::run, net::kill_port};
+
+
+#[derive(Args, Debug, Clone)]
+pub struct ExportOptions {
+    #[arg(long, default_value = "slides.pdf")]
+    pub output: String,
+    #[arg(long, default_value_t = 3000)]
+    pub port: u16,
+
+}
+pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
+
+
+    let output = Command::new("npm")
+            .args(["install", "decktape@3.15.0"])
+            .current_dir(".")
+            .output()?;
+
+    if !output.status.success() {
+        eprintln!(
+            "Decktape installation failure: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return Err("npm init failed".into());
+    }
+
+    // decktape automatic http://localhost:3000/ Desktop/IntroToRust/slides.pdf
+
+    // let 
+
+
+    let _run_handle = std::thread::spawn(run::run);
+
+
+    let addr = format!("http://localhost:{}", opts.port);
+
+    let export_output = Command::new("decktape")
+        .args(["automatic", &addr, &opts.output])
+        .output()?;
+
+    if kill_port(opts.port).is_err() {
+        println!("Warning: could not kill process on port, project could still be running");
+    }
+    if !export_output.status.success() {
+        eprintln!(
+            "Decktape PDF export failure: {}",
+            String::from_utf8_lossy(&export_output.stderr)
+        );
+        return Err("npm init failed".into());
+    }
+
+
+
+
+    Ok(())
+}

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,9 +1,15 @@
-use std::{error::Error, process::Command, sync::{Arc, atomic::{AtomicBool, Ordering}}};
+use std::{
+    error::Error,
+    process::Command,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use clap::Args;
 
 use crate::{cmd::run, net::kill_port};
-
 
 /// Options struct for the export subcommand
 #[derive(Args, Debug, Clone)]
@@ -14,21 +20,18 @@ pub struct ExportOptions {
     /// Port the project runs on
     #[arg(long, default_value_t = 3000)]
     pub port: u16,
-
 }
 
 /// Export the current Oseda project to a PDF file via `decktape`
 pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
-
     if kill_port(opts.port).is_err() {
         eprintln!("Warning, could not kill value on desired port")
     }
 
-
     let output = Command::new("npm")
-            .args(["install", "decktape@3.15.0"])
-            .current_dir(".")
-            .output()?;
+        .args(["install", "decktape@3.15.0"])
+        .current_dir(".")
+        .output()?;
 
     if !output.status.success() {
         eprintln!(
@@ -43,9 +46,8 @@ pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let run_flag = shutdown_flag.clone();
 
-
     let run_handle = std::thread::spawn(move || run::run_with_shutdown(run_flag));
-    
+
     // wait a moment for the localhost server to spin up
     std::thread::sleep(std::time::Duration::from_millis(10000));
 
@@ -56,7 +58,6 @@ pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
         .args(["automatic", &addr, &opts.output])
         .output()?;
 
-        
     // send shutdown flag, should signal to run_with_shutdown to kill the process
     shutdown_flag.store(true, Ordering::SeqCst);
     // wait to run to terminate (hopefully gracefully) and join the process to cur. thread
@@ -69,7 +70,6 @@ pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
         );
         return Err("npm init failed".into());
     }
-
 
     Ok(())
 }

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -5,14 +5,19 @@ use clap::Args;
 use crate::{cmd::run, net::kill_port};
 
 
+/// Options struct for the export subcommand
 #[derive(Args, Debug, Clone)]
 pub struct ExportOptions {
+    /// String name of the output PDF file
     #[arg(long, default_value = "slides.pdf")]
     pub output: String,
+    /// Port the project runs on
     #[arg(long, default_value_t = 3000)]
     pub port: u16,
 
 }
+
+/// Export the current Oseda project to a PDF file via `decktape`
 pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
 
     if kill_port(opts.port).is_err() {

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -15,6 +15,10 @@ pub struct ExportOptions {
 }
 pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
 
+    if kill_port(opts.port).is_err() {
+        eprintln!("Warning, could not kill value on desired port")
+    }
+
 
     let output = Command::new("npm")
             .args(["install", "decktape@3.15.0"])
@@ -30,8 +34,6 @@ pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
     }
 
     // decktape automatic http://localhost:3000/ Desktop/IntroToRust/slides.pdf
-
-    // let 
 
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let run_flag = shutdown_flag.clone();

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, process::Command, sync::{Arc, atomic::AtomicBool}};
+use std::{error::Error, process::Command, sync::{Arc, atomic::{AtomicBool, Ordering}}};
 
 use clap::Args;
 
@@ -33,19 +33,28 @@ pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
 
     // let 
 
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    let run_flag = shutdown_flag.clone();
 
-    let _run_handle = std::thread::spawn(run::run);
 
+    let run_handle = std::thread::spawn(move || run::run_with_shutdown(run_flag));
+    
+    // wait a moment for the localhost server to spin up
+    std::thread::sleep(std::time::Duration::from_millis(10000));
 
     let addr = format!("http://localhost:{}", opts.port);
 
+    // run decktape, assuming the server has spun up by now
     let export_output = Command::new("decktape")
         .args(["automatic", &addr, &opts.output])
         .output()?;
 
-    if kill_port(opts.port).is_err() {
-        println!("Warning: could not kill process on port, project could still be running");
-    }
+        
+    // send shutdown flag, should signal to run_with_shutdown to kill the process
+    shutdown_flag.store(true, Ordering::SeqCst);
+    // wait to run to terminate (hopefully gracefully) and join the process to cur. thread
+    let _ = run_handle.join();
+
     if !export_output.status.success() {
         eprintln!(
             "Decktape PDF export failure: {}",
@@ -53,8 +62,6 @@ pub fn export(opts: ExportOptions) -> Result<(), Box<dyn Error>> {
         );
         return Err("npm init failed".into());
     }
-
-
 
 
     Ok(())

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3,3 +3,4 @@ pub mod deploy;
 pub mod fork;
 pub mod init;
 pub mod run;
+pub mod export;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,6 +1,6 @@
 pub mod check;
 pub mod deploy;
+pub mod export;
 pub mod fork;
 pub mod init;
 pub mod run;
-pub mod export;

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,4 +1,11 @@
-use std::{process::Command, sync::{Arc, atomic::{AtomicBool, Ordering}, mpsc}, time::Duration};
+use std::{
+    process::Command,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 /// More in depth errors that could cause a project not to run
 #[derive(Debug)]
@@ -69,17 +76,17 @@ pub fn run_with_shutdown(shutdown_flag: Arc<AtomicBool>) -> Result<(), OsedaRunE
     ctrlc::set_handler(move || {
         println!("\nSIGINT received. Attempting graceful shutdown...");
         ctrlc_flag.store(true, Ordering::SeqCst);
-    }).map_err(|e| {
-            println!("Error setting ctrl+c handler: {e}");
-            OsedaRunError::ServeError("failed to set handler".into())
+    })
+    .map_err(|e| {
+        println!("Error setting ctrl+c handler: {e}");
+        OsedaRunError::ServeError("failed to set handler".into())
     })?;
 
-    
     // block until ctrl+c or sigkill or flag set otherwise (e.g. via export)
     while !shutdown_flag.load(Ordering::SeqCst) {
-        std::thread::sleep(Duration::from_millis(100)); 
+        std::thread::sleep(Duration::from_millis(100));
     }
-    
+
     // attempt to kill the child process
     if let Err(e) = child.kill() {
         println!("Failed to kill `serve`: {e}");

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,4 +1,4 @@
-use std::{process::Command, sync::mpsc};
+use std::{process::Command, sync::{Arc, atomic::AtomicBool, mpsc}};
 
 /// More in depth errors that could cause a project not to run
 #[derive(Debug)]
@@ -28,6 +28,11 @@ impl std::fmt::Display for OsedaRunError {
 /// * `Ok(())` if both the build and serve steps succeed
 /// * `Err(OsedaRunError)` if any step fails (missing vite isn't installed, or `serve` fails to start)
 pub fn run() -> Result<(), OsedaRunError> {
+    // todo refactor the other check command to use this
+    run_with_shutdown(Arc::new(AtomicBool::new(false)))
+}
+
+pub fn run_with_shutdown(shutdown_flag: Arc<AtomicBool>) -> Result<(), OsedaRunError> {
     // command run failure and command status are considered different, handled accordingly
     match Command::new("npx").arg("vite").arg("build").status() {
         Ok(status) => {

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,4 +1,4 @@
-use std::{process::Command, sync::{Arc, atomic::AtomicBool, mpsc}};
+use std::{process::Command, sync::{Arc, atomic::{AtomicBool, Ordering}, mpsc}, time::Duration};
 
 /// More in depth errors that could cause a project not to run
 #[derive(Debug)]
@@ -64,16 +64,22 @@ pub fn run_with_shutdown(shutdown_flag: Arc<AtomicBool>) -> Result<(), OsedaRunE
     // spawn will leave child running the background. Need to listen for ctrl+c, snatch it. Then kill subprocess
 
     // https://github.com/Detegr/rust-ctrlc
-    let (tx, rx) = mpsc::channel();
+    // let (tx, rx) = mpsc::channel();
+    let ctrlc_flag = shutdown_flag.clone();
     ctrlc::set_handler(move || {
         println!("\nSIGINT received. Attempting graceful shutdown...");
-        let _ = tx.send(());
-    })
-    .expect("Error setting Ctrl+C handler");
+        ctrlc_flag.store(true, Ordering::SeqCst);
+    }).map_err(|e| {
+            println!("Error setting ctrl+c handler: {e}");
+            OsedaRunError::ServeError("failed to set handler".into())
+    })?;
 
-    // block until ctrl+c
-    rx.recv().unwrap();
-
+    
+    // block until ctrl+c or sigkill or flag set otherwise (e.g. via export)
+    while !shutdown_flag.load(Ordering::SeqCst) {
+        std::thread::sleep(Duration::from_millis(100)); 
+    }
+    
     // attempt to kill the child process
     if let Err(e) = child.kill() {
         println!("Failed to kill `serve`: {e}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,4 +33,6 @@ pub enum Commands {
     Deploy(cmd::deploy::DeployOptions),
     /// Fork the library repository to submit your course
     Fork,
+    /// Export the Oseda project to a PDF file
+    Export(cmd::export::ExportOptions),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,5 +34,7 @@ pub enum Commands {
     /// Fork the library repository to submit your course
     Fork,
     /// Export the Oseda project to a PDF file
+    /// This will install the npm package `decktape`
+    /// This relies on a chromium backend, as a result, it may take a while to run
     Export(cmd::export::ExportOptions),
 }


### PR DESCRIPTION
Add subcommand for PDF exporting. 

`oseda export [optional port] [optional filename]`
```rust
#[derive(Args, Debug, Clone)]
pub struct ExportOptions {
    /// String name of the output PDF file
    #[arg(long, default_value = "slides.pdf")]
    pub output: String,
    /// Port the project runs on
    #[arg(long, default_value_t = 3000)]
    pub port: u16,
}
```

Also rewrote the run command to support killing via an Arc<AtomicBool>



