### PR TITLE
Highlight.js + Remove deprecated `vite-single-file`

### DIFF
--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -12,6 +12,6 @@ cd test
 
 
 pwd
-./oseda init --title ExampleProject --tags economics ComPuterScience --color red --template MaRKDoWN
+./oseda init --title ExampleProject --tags economics ComPuterScience --color red --template HTML
 
 mv oseda ExampleProject

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -87,7 +87,7 @@ pub fn init(opts: InitOptions) -> Result<(), Box<dyn Error>> {
 
     let npm_commands = vec![
         format!("install --save-dev vite@5.4.21 http-server@14.1.1"),
-        format!("install reveal.js@5.2.1 serve@14.2.6"),
+        format!("install reveal.js@5.2.1 serve@14.2.6 highlight.js@11.12.0"),
         format!("install patch-package@8.0.1"),
     ];
 


### PR DESCRIPTION
- Install `highlight.js` by default, in case user wants to use these themes
    - As of now, there is no way of actually setting those other themes up in init (which would be cool to add eventually)
    
 Closes #79 
